### PR TITLE
Fix the empty attributes return

### DIFF
--- a/lib/jsonapi-params/param.rb
+++ b/lib/jsonapi-params/param.rb
@@ -126,7 +126,6 @@ module JSONAPI
 
       # Are the attributes an ActionController::Parameters instance?
       #
-      # @param [Hash]
       # @return [Boolean]
       # @!visibility private
       def strong_parameters?

--- a/lib/jsonapi-params/param.rb
+++ b/lib/jsonapi-params/param.rb
@@ -82,7 +82,7 @@ module JSONAPI
         attributes = @data['attributes'] || {}
         attributes = attributes.slice(*self.class.whitelist_attributes)
         attributes = attributes.merge(relationships)
-        collection_attributes = strong_parameters?(attributes) ? attributes.to_unsafe_h : attributes.to_h
+        collection_attributes = strong_parameters? ? attributes.to_unsafe_h : attributes.to_h
 
         collection_attributes.inject({}) do |attributes, (key, value)|
           attributes[key.to_s.underscore.to_sym] = value
@@ -129,7 +129,7 @@ module JSONAPI
       # @param [Hash]
       # @return [Boolean]
       # @!visibility private
-      def strong_parameters?(attrs)
+      def strong_parameters?
         Object.const_defined?('ActionController::Parameters')
       end
     end

--- a/lib/jsonapi-params/param.rb
+++ b/lib/jsonapi-params/param.rb
@@ -129,7 +129,7 @@ module JSONAPI
       # @return [Boolean]
       # @!visibility private
       def strong_parameters?
-        Object.const_defined?('ActionController::Parameters')
+        Object.const_defined?('ActionController::Parameters') && @data.is_a?(ActionController::Parameters)
       end
     end
   end

--- a/lib/jsonapi-params/param.rb
+++ b/lib/jsonapi-params/param.rb
@@ -82,8 +82,9 @@ module JSONAPI
         attributes = @data['attributes'] || {}
         attributes = attributes.slice(*self.class.whitelist_attributes)
         attributes = attributes.merge(relationships)
+        collection_attributes = strong_parameters?(attributes) ? attributes.to_unsafe_h : attributes.to_h
 
-        attributes.to_h.inject({}) do |attributes, (key, value)|
+        collection_attributes.inject({}) do |attributes, (key, value)|
           attributes[key.to_s.underscore.to_sym] = value
           attributes
         end
@@ -121,6 +122,15 @@ module JSONAPI
       # @!visibility private
       def params_klass(key)
         "#{key}Param".classify.constantize
+      end
+
+      # Are the attributes an ActionController::Parameters instance?
+      #
+      # @param [Hash]
+      # @return [Boolean]
+      # @!visibility private
+      def strong_parameters?(attrs)
+        Object.const_defined?('ActionController::Parameters')
       end
     end
   end


### PR DESCRIPTION
When Rails Strong Parameters are set in conjunction with this gem, only the permitted parameters were returned on the `attributes` method.

This PR fix it, so now you only need to add the param in your `Param` class, without concerning about Strong Parameters.
